### PR TITLE
Add USB UART Debugging Output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,3 +126,10 @@ target_link_libraries(sd2psx
 set_target_properties(sd2psx PROPERTIES PICO_TARGET_LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/memmap_custom.ld)
 
 pico_add_extra_outputs(sd2psx)
+
+set(DEBUG_USB_UART OFF CACHE BOOL "Activate UART over USB for debugging")
+
+if(DEBUG_USB_UART)
+    add_definitions(-DDEBUG_USB_UART)
+    pico_enable_stdio_usb(sd2psx ENABLED)
+endif()

--- a/src/debug.c
+++ b/src/debug.c
@@ -32,10 +32,6 @@ void __time_critical_func(debug_printf)(const char *format, ...) {
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
 
-#if DEBUG_USB_UART
-    printf("%s", buf);
-#endif
-
     for (char *c = buf; *c; ++c)
         debug_put(*c);
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -32,6 +32,10 @@ void __time_critical_func(debug_printf)(const char *format, ...) {
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
 
+#if DEBUG_USB_UART
+    printf("%s", buf);
+#endif
+
     for (char *c = buf; *c; ++c)
         debug_put(*c);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,12 @@ int main() {
     input_init();
     check_bootloader_reset();
 
+#if DEBUG_USB_UART
+    stdio_usb_init();
+    sleep_ms(2000);
+#else
     stdio_uart_init_full(UART_PERIPH, UART_BAUD, UART_TX, UART_RX);
+#endif
 
     printf("prepare...\n");
     int mhz = 240;

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,9 @@ static void debug_task(void) {
             if (ch == '\n')
                 uart_putc_raw(UART_PERIPH, '\r');
             uart_putc_raw(UART_PERIPH, ch);
+            #if DEBUG_USB_UART
+                putchar(ch);
+            #endif
         } else {
             break;
         }


### PR DESCRIPTION
This PR adds debug capabilities on USB UART.
It also adds a build product as uf2 for this change as action.

To use USB debug, set CMake Variable ```DEBUG_USB_UART```